### PR TITLE
Fix birth/survival rule bug in Game of Life

### DIFF
--- a/GameOfLife/src/main/java/com/example/deneme/Game.java
+++ b/GameOfLife/src/main/java/com/example/deneme/Game.java
@@ -2,17 +2,21 @@ package com.example.deneme;
 
 public class Game {
 
-    public void applyBirthRule (Cell cell){
-        if(!cell.isAlive() && cell.getNeighbours()==3){
+    public void applyBirthRule(Cell cell) {
+        if (!cell.isAlive() && cell.getNeighbours() == 3) {
             cell.setAlive(true);
-        }cell.setAlive(false);
+        } else {
+            cell.setAlive(false);
+        }
     }
 
-    public void applySurvivalRule(Cell cell){
-          if (cell.getNeighbours()==2||cell.getNeighbours()==3){
-              cell.setAlive(true);
-          }cell.setAlive(false);
-       }
+    public void applySurvivalRule(Cell cell) {
+        if (cell.getNeighbours() == 2 || cell.getNeighbours() == 3) {
+            cell.setAlive(true);
+        } else {
+            cell.setAlive(false);
+        }
+    }
 
     private Grid grid;
 

--- a/GameOfLife/src/test/java/com/example/deneme/GameRulesTest.java
+++ b/GameOfLife/src/test/java/com/example/deneme/GameRulesTest.java
@@ -1,0 +1,49 @@
+package com.example.deneme;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GameRulesTest {
+
+    @Test
+    void birthRuleSetsAliveWhenExactlyThreeNeighbors() {
+        Cell cell = new Cell();
+        cell.setAlive(false);
+        cell.setNeighbours(3);
+        Game game = new Game(1, 1);
+        game.applyBirthRule(cell);
+        assertTrue(cell.isAlive(), "Cell should become alive when it has exactly three neighbours");
+    }
+
+    @Test
+    void birthRuleKeepsDeadWhenNotThreeNeighbors() {
+        Cell cell = new Cell();
+        cell.setAlive(false);
+        cell.setNeighbours(2);
+        Game game = new Game(1, 1);
+        game.applyBirthRule(cell);
+        assertFalse(cell.isAlive(), "Cell should remain dead when it does not have three neighbours");
+    }
+
+    @Test
+    void survivalRuleKeepsAliveWithTwoOrThreeNeighbors() {
+        Cell cell = new Cell();
+        cell.setNeighbours(2);
+        Game game = new Game(1, 1);
+        game.applySurvivalRule(cell);
+        assertTrue(cell.isAlive(), "Cell should stay alive with two neighbours");
+
+        cell.setNeighbours(3);
+        game.applySurvivalRule(cell);
+        assertTrue(cell.isAlive(), "Cell should stay alive with three neighbours");
+    }
+
+    @Test
+    void survivalRuleKillsWithOtherNeighborCounts() {
+        Cell cell = new Cell();
+        cell.setNeighbours(1);
+        Game game = new Game(1, 1);
+        game.applySurvivalRule(cell);
+        assertFalse(cell.isAlive(), "Cell should die with neighbour count other than two or three");
+    }
+}


### PR DESCRIPTION
## Summary
- fix logic in `Game.applyBirthRule` and `Game.applySurvivalRule`
- add unit tests for the rules

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a7d7f9e3c832a9ed3c12d1e71f51f