### PR TITLE
Add docs for each web service

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ This repository includes various Java projects:
 - **[ProxyDesignPattern](https://github.com/AhmetTK4/JavaProjects/tree/main/ProxyDesignPattern)**: Implements the Proxy design pattern in Java.
 - **[kullanici-servis](https://github.com/AhmetTK4/JavaProjects/tree/main/kullanici-servis)**: A service application for user management.
 
+## Service Documentation
+For details of each web service, see the [docs](docs) folder.
+
 ## Installation
 
 1. Clone this repository to your local machine:

--- a/docs/GameOfLife.md
+++ b/docs/GameOfLife.md
@@ -1,0 +1,10 @@
+# GameOfLife Service
+
+Spring Boot implementation demonstrating Conway's Game of Life. Provides a REST endpoint to retrieve the next generation grid.
+
+## Endpoints
+
+| Method | Path              | Description                                |
+|-------|------------------|--------------------------------------------|
+| GET   | `/nextGeneration` | Returns the next generation of cells based on provided `rows` and `cols` query parameters. |
+

--- a/docs/PlayWithCaches.md
+++ b/docs/PlayWithCaches.md
@@ -1,0 +1,10 @@
+# PlayWithCaches Service
+
+Demonstrates caching mechanisms using Spring Boot.
+
+## Endpoints
+
+| Method | Path   | Parameters | Description                |
+|-------|-------|------------|----------------------------|
+| GET   | `/data` | `param` (query) | Retrieves data, using caching for repeated calls. |
+

--- a/docs/PlayWithGenerics.md
+++ b/docs/PlayWithGenerics.md
@@ -1,0 +1,13 @@
+# PlayWithGenerics Service
+
+Spring Boot project demonstrating usage of generics with REST APIs.
+
+## Endpoints
+
+| Method | Path | Description |
+|-------|------|-------------|
+| POST | `/api/generic/user` | Add a new `User` to the list. |
+| GET | `/api/generic/users` | Retrieve all stored `User` objects. |
+| POST | `/api/generic/string` | Add a new `String` value to the list. |
+| GET | `/api/generic/strings` | Retrieve all stored strings. |
+

--- a/docs/PlayWithJson.md
+++ b/docs/PlayWithJson.md
@@ -1,0 +1,12 @@
+# PlayWithJson Service
+
+Demonstrates handling of JSON files via REST endpoints using Spring Boot.
+
+## Endpoints
+
+| Method | Path | Description |
+|-------|------|-------------|
+| GET | `/api/data` | Retrieve all entries from `data.json`. |
+| POST | `/api/data` | Add a new entry and persist to `data.json`. |
+| DELETE | `/api/data/{id}` | Delete an entry by its ID. |
+

--- a/docs/PlayWithStreams.md
+++ b/docs/PlayWithStreams.md
@@ -1,0 +1,13 @@
+# PlayWithStreams Service
+
+Spring Boot project illustrating stream operations over employee data.
+
+## Endpoints
+
+| Method | Path | Description |
+|-------|------|-------------|
+| GET | `/employees/high-salary` | List employees with salary greater than 5000. |
+| GET | `/employees/names-uppercase` | Return all employee names in uppercase. |
+| GET | `/employees/group-by-department` | Group employees by department. |
+| GET | `/employees/total-salary` | Calculate total salary of all employees. |
+

--- a/docs/PlayWithThreads.md
+++ b/docs/PlayWithThreads.md
@@ -1,0 +1,16 @@
+# PlayWithThreads Service
+
+Showcases multithreading techniques with Spring Boot endpoints.
+
+## Endpoints
+
+| Method | Path | Description |
+|-------|------|-------------|
+| GET | `/start-tasks` | Trigger asynchronous tasks. Accepts `taskCount` query param. |
+| POST | `/send-message` | Send a message to Kafka topic. |
+| POST | `/scheduler/task1` | Trigger scheduled task 1. |
+| POST | `/scheduler/task2` | Trigger scheduled task 2. |
+| POST | `/scheduler/notify` | Notify when tasks complete. |
+| POST | `/scheduler/send-email` | Send an email with `to`, `subject` and `text` parameters. |
+| GET | `/tasks/counts` | Retrieve scheduler task counts. |
+

--- a/docs/ProxyDesignPattern.md
+++ b/docs/ProxyDesignPattern.md
@@ -1,0 +1,12 @@
+# ProxyDesignPattern Service
+
+Example project implementing the Proxy design pattern with REST endpoints.
+
+## Endpoints
+
+| Method | Path | Description |
+|-------|------|-------------|
+| GET | `/api/users/{id}` | Get a user by id. |
+| GET | `/api/users/name/{name}` | Find user by username. |
+| PUT | `/api/users/{id}/email` | Update user email using `newEmail` parameter. |
+

--- a/docs/jacoco-demo.md
+++ b/docs/jacoco-demo.md
@@ -1,0 +1,4 @@
+# jacoco-demo
+
+Spring Boot project demonstrating JaCoCo code coverage. This module does not expose REST endpoints.
+

--- a/docs/kullanici-servis.md
+++ b/docs/kullanici-servis.md
@@ -1,0 +1,13 @@
+# kullanici-servis
+
+Quarkus based service for managing users.
+
+## Endpoints
+
+| Method | Path | Description |
+|-------|------|-------------|
+| GET | `/kullanici` | List all users. |
+| POST | `/kullanici` | Create a new user. |
+| PUT | `/kullanici/{id}` | Update an existing user. |
+| DELETE | `/kullanici/{id}` | Delete a user. |
+


### PR DESCRIPTION
## Summary
- document all web services under new `docs` folder
- reference the `docs` folder from the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a7dc9d544832ab9bcb15773b0d407