### PR TITLE
Add CI build for kullanici-servis

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        project: [PlayWithGenerics, PlayWithStreams, ProxyDesignPattern] 
+        project: [PlayWithGenerics, PlayWithStreams, ProxyDesignPattern, kullanici-servis]
 
     steps:
       - name: Checkout code

--- a/kullanici-servis/.gitignore
+++ b/kullanici-servis/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/kullanici-servis/README.md
+++ b/kullanici-servis/README.md
@@ -9,7 +9,7 @@ If you want to learn more about Quarkus, please visit its website: <https://quar
 You can run your application in dev mode that enables live coding using:
 
 ```shell script
-./mvnw compile quarkus:dev
+mvn compile quarkus:dev
 ```
 
 > **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at <http://localhost:8080/q/dev/>.
@@ -19,7 +19,7 @@ You can run your application in dev mode that enables live coding using:
 The application can be packaged using:
 
 ```shell script
-./mvnw package
+mvn package
 ```
 
 It produces the `quarkus-run.jar` file in the `target/quarkus-app/` directory.
@@ -30,7 +30,7 @@ The application is now runnable using `java -jar target/quarkus-app/quarkus-run.
 If you want to build an _über-jar_, execute the following command:
 
 ```shell script
-./mvnw package -Dquarkus.package.jar.type=uber-jar
+mvn package -Dquarkus.package.jar.type=uber-jar
 ```
 
 The application, packaged as an _über-jar_, is now runnable using `java -jar target/*-runner.jar`.
@@ -40,13 +40,13 @@ The application, packaged as an _über-jar_, is now runnable using `java -jar ta
 You can create a native executable using:
 
 ```shell script
-./mvnw package -Dnative
+mvn package -Dnative
 ```
 
 Or, if you don't have GraalVM installed, you can run the native executable build in a container using:
 
 ```shell script
-./mvnw package -Dnative -Dquarkus.native.container-build=true
+mvn package -Dnative -Dquarkus.native.container-build=true
 ```
 
 You can then execute your native executable with: `./target/kullanici-servis-1.0-SNAPSHOT-runner`


### PR DESCRIPTION
## Summary
- compile `kullanici-servis` as part of the CI matrix
- document using `mvn` commands for the Quarkus service
- add Maven `.gitignore` for `kullanici-servis`

## Testing
- `mvn -f kullanici-servis/pom.xml -q package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bcb4ce598832abe10789537bca746